### PR TITLE
Update for symfony 2.6

### DIFF
--- a/Form/Type/ColorPickerType.php
+++ b/Form/Type/ColorPickerType.php
@@ -88,7 +88,8 @@ class ColorPickerType extends ChoiceType {
             'include_js'        => false,
             'include_js_constructor'=>true,
             'include_css'       => false,
-            'picker'            => false
+            'picker'            => false,
+            'placeholder'       => false
         ));
 
     }


### PR DESCRIPTION
`ColorPickerType` extends `ChoiceType`, which in newer versions of symfony expects a default value for the property `placeholder`.
